### PR TITLE
Updated to reflect VSTS reband to Azure DevOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 <table style="width: 100%; border-style: none;"><tr>
 <td width="140px" style="text-align: center;"><img src="websphere_icon.png" style="max-width:100%" /></td>
-<td><strong>Visual Studio Team Services Extension for IBM WebSphere Application Server</strong><br />
+<td><strong>Azure DevOps Extension for IBM WebSphere Application Server</strong><br />
 <i>Provides deployment task that automatically installs/updates enterprise applications in WebSphere Application Servers.</i><br />
 <a href="https://marketplace.visualstudio.com/items/ms-vsts.ibm-websphere">Install now!</a>
 </td>
 </tr></table>
 
-# Visual Studio Team Services Extension for IBM WebSphere Application Server
+# Azure DevOps for IBM WebSphere Application Server
 
 This extension contains a deployment task which allows you to automate the installation and update of applications to IBM WebSphere Application Servers. This extension installs the following components:
-* A service endpoint for connecting to IBM WebSphere Application Server on Visual Studio Team Services and Team Foundation Server 2017.
+* A service endpoint for connecting to IBM WebSphere Application Server on Azure DevOps and Team Foundation Server 2017.
 * A build task to install / update enterprise applications on WebSphere Application Servers.
 
 ## Prerequisites
@@ -27,7 +27,7 @@ Once you have set up the WebSphere environment, perform the following steps to a
 
 1. Install the [IBM WebSphere extension](https://marketplace.visualstudio.com/items/ms-vsts.ibm-webshepere) from the Team Services Marketplace.
 
-2. Go to your Visual Studio Team Services or TFS project, click on the **Build** tab, and create a new build definition (the "+" icon) that is hooked up to your project's appropriate source repository.
+2. Go to your Azure DevOps or TFS project, click on the **Build** tab, and create a new build definition (the "+" icon) that is hooked up to your project's appropriate source repository.
 
 3. Click **Add build step...** and select the necessary tasks to generate your release assets (e.g. **Maven**, **Gradle**).
 
@@ -68,7 +68,7 @@ it will install it; Otherwise it will update the target application.
 The tasks provide two options to connect to IBM WebSphere Application Server:
 
 1. Connecting with an "IBM WebSphere" endpoint.
-    * This option is supported on Visual Studio Team Services and Team Foundation Server 2017.  On Team Foundation Server 2015, please use other options to connect.
+    * This option is supported on Azure DevOps and Team Foundation Server 2017.  On Team Foundation Server 2015, please use other options to connect.
 
     ![IBM websphere Endpoint](images/websphere_endpoint.PNG)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </td>
 </tr></table>
 
-# Azure DevOps for IBM WebSphere Application Server
+# Azure DevOps Extension for IBM WebSphere Application Server
 
 This extension contains a deployment task which allows you to automate the installation and update of applications to IBM WebSphere Application Servers. This extension installs the following components:
 * A service endpoint for connecting to IBM WebSphere Application Server on Azure DevOps and Team Foundation Server 2017.

--- a/docs/vsts-README.md
+++ b/docs/vsts-README.md
@@ -1,7 +1,7 @@
-# Visual Studio Team Services Extension for IBM WebSphere Application Server
+# Azure DevOps Extension for IBM WebSphere Application Server
 
 This extension contains a deployment task which allows you to automate the installation and update of applications to IBM WebSphere Application Servers. This extension installs the following components:
-* A service endpoint for connecting to IBM WebSphere Application Server on Visual Studio Team Services and Team Foundation Server 2017.
+* A service endpoint for connecting to IBM WebSphere Application Server on Azure DevOps and Team Foundation Server 2017.
 * A build task to install / update enterprise application on WebSphere Application Servers.
 
 ## Prerequisites
@@ -18,7 +18,7 @@ Once you have set up the WebSphere environment, perform the following steps to a
 
 1. Install the [IBM WebSphere extension](https://marketplace.visualstudio.com/items/ms-vsts.ibm-webshepere) from the Team Services Marketplace.
 
-2. Go to your Visual Studio Team Services or TFS project, click on the **Build** tab, and create a new build definition (the "+" icon) that is hooked up to your project's appropriate source repository.
+2. Go to your Azure DevOps or TFS project, click on the **Build** tab, and create a new build definition (the "+" icon) that is hooked up to your project's appropriate source repository.
 
 3. Click **Add build step...** and select the necessary tasks to generate your release assets (e.g. **Maven**, **Gradle**).
 
@@ -58,7 +58,7 @@ Once you have set up the WebSphere environment, perform the following steps to a
 The tasks provide two options to connect to IBM WebSphere Application Server:
 
 1. Connecting with an "IBM WebSphere" endpoint.
-    * This option is supported on Visual Studio Team Services and Team Foundation Server 2017.  On Team Foundation Server 2015, please use other options to connect.
+    * This option is supported on Azure DevOps and Team Foundation Server 2017.  On Team Foundation Server 2015, please use other options to connect.
 
     ![IBM websphere Endpoint](images/websphere_endpoint.PNG)
 


### PR DESCRIPTION
Visual Studio Team Services has now been rebranded to Azure DevOps. I have updated the Readme file to reflect this change. This will ensure that users will be able to follow the documentation correctly.